### PR TITLE
Move typescript dependency to peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-no-date-parsing",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Disallow string parsing with new Date and Date.parse.",
   "main": "./dist/index.js",
   "scripts": {
@@ -14,7 +14,9 @@
     "url": "https://github.com/amzn/eslint-plugin-no-date-parsing"
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "^4.28.3",
+    "@typescript-eslint/experimental-utils": "^4.28.3"
+  },
+  "peerDependencies": {
     "typescript": "^4.3.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Our consuming project had multiple typescripts in node_modules. This eslint rule should be using the parent project's typescript install.