### PR TITLE
Add support for eslint extend config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,15 @@
 module.exports.rules = {
   'no-date-parsing': require('./rules/no-date-parsing')
 };
+
+module.exports.configs = {
+  recommended: {
+    plugins: ["no-date-parsing"],
+    env: {
+      browser: true,
+    },
+    rules: {
+      "no-date-parsing/no-date-parsing": "error",
+    },
+  }
+};


### PR DESCRIPTION
Added recommended configuration for eslint. this will make it easy to use with eslint extends format. no need to add `plugins` and `rules` separately, just use it like below.

```
extends: [
  "plugin:no-date-parsing/recommended",
]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
